### PR TITLE
Add data source and analysis docs with vibe demo

### DIFF
--- a/docs/data-analysis.md
+++ b/docs/data-analysis.md
@@ -1,0 +1,13 @@
+# Data Analysis
+
+This page describes the analytical methods applied to the project's datasets. It provides sample code and explanations of statistical or visualization techniques.
+
+```python
+# Example analysis snippet
+import matplotlib.pyplot as plt
+
+plt.plot([1, 2, 3], [4, 5, 6])
+plt.title('Sample Plot')
+plt.show()
+```
+

--- a/docs/data-source.md
+++ b/docs/data-source.md
@@ -1,0 +1,12 @@
+# Data Source
+
+This page documents the datasets used in this project. It outlines the origin of the data, how it was collected, and any relevant preprocessing steps.
+
+```python
+# Example of loading a dataset
+import pandas as pd
+
+data = pd.read_csv('path/to/dataset.csv')
+data.head()
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,26 @@ We welcome contributions from all group members. To maintain the quality and int
 
 If you encounter any issues or have questions about how to contribute, please refer to the [ESIIL Support Page](https://esiil.org/support) or contact the repository maintainers directly.
 
+## Vibe Code Demo
+
+Below are interactive code blocks demonstrating how to load data and perform a basic analysis. Click the code to run it in your browser.
+
+```vibe
+# Data source example
+import pandas as pd
+pd.read_csv('path/to/dataset.csv').head()
+```
+
+```vibe
+# Data analysis example
+import matplotlib.pyplot as plt
+plt.plot([1, 2, 3], [4, 5, 6])
+plt.title("Sample Plot")
+plt.show()
+```
+
+For more details, see the [data source](data-source.md) and [data analysis](data-analysis.md) documentation.
+
 ## Customize Your Repository
 
 As a new working group, you'll want to make this repository your own. Here's how to get started:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: 'Ty's one off education site'
+site_name: "Ty's one off education site"
 site_description: 'Teaching people how to set up github'
 site_author: Ty Tuff
 site_url: https://cu-esiil.github.io/Ty_test
@@ -13,6 +13,8 @@ copyright: 'Copyright &copy; 2023 University of Colorado Boulder'
 # Page tree
 nav:
   - Home: index.md
+  - Data Source: data-source.md
+  - Data Analysis: data-analysis.md
   - Resources:
        - Code of Conduct: resources/code-of-conduct.md
        - Participant agreement: resources/participant_agreement.md


### PR DESCRIPTION
## Summary
- add `data-source.md` and `data-analysis.md` pages
- showcase new pages with a vibe code demo on the site homepage
- expose new pages in navigation

## Testing
- `pytest`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68a5e21ddf0c83258f9419e044d255e0